### PR TITLE
Set default value for searchTags

### DIFF
--- a/controller/login.js
+++ b/controller/login.js
@@ -1,3 +1,4 @@
+/*
 const { PrismaClient } = require('@prisma/client');
 const { json } = require('express');
 const prisma = new PrismaClient();
@@ -14,3 +15,4 @@ const getToken = async ( req, res ) => {
 module.exports = {
   getToken
 };
+*/

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,7 +33,7 @@ model Node {
   id         Int     @id @default(autoincrement())
   isWaypoint Boolean
   position   Float[]
-  searchTags    String[] 
+  searchTags    String[] @default([])
   //hasElevator   Boolean
   //hasStairs     Boolean
   //hasDoor       Boolean

--- a/router/login.js
+++ b/router/login.js
@@ -1,3 +1,4 @@
+/*
 const express = require('express');
 const router = express.Router();
 
@@ -6,3 +7,4 @@ const login = require('../controller/login');
 router.get('/token', login.getToken);
 
 module.exports = router;
+*/

--- a/server.js
+++ b/server.js
@@ -6,7 +6,7 @@ const port = 3001;
 //const nodeRouter = require('./router/node');
 //const edgeRouter = require('./router/edge');
 const graphRouter = require('./router/graph');
-const loginRouter = require('./router/login');
+//const loginRouter = require('./router/login');
 
 
 app.use(cors());
@@ -18,7 +18,7 @@ app.use(express.urlencoded({ extended: true }));
 //app.use('/node', nodeRouter);
 //app.use('/edge', edgeRouter);
 app.use('/graph', graphRouter);
-app.use('/login', loginRouter);
+//app.use('/login', loginRouter);
 
 
 app.listen(port, () => {


### PR DESCRIPTION
This pull request includes several changes to temporarily disable the login functionality and modify the Prisma schema. The most important changes include commenting out the login routes and controller, and setting a default value for the `searchTags` field in the Prisma schema.

Disabling login functionality:

* [`controller/login.js`](diffhunk://#diff-c3404dba3a8aa2a574cedf349222cdc37ada95fdd7d90471b960c1918e67c76cR1): Commented out the `getToken` function export and Prisma client initialization. [[1]](diffhunk://#diff-c3404dba3a8aa2a574cedf349222cdc37ada95fdd7d90471b960c1918e67c76cR1) [[2]](diffhunk://#diff-c3404dba3a8aa2a574cedf349222cdc37ada95fdd7d90471b960c1918e67c76cR18)
* [`router/login.js`](diffhunk://#diff-3185d28885bace3e5200daf57d75adf14169979d0f6b13da6719767e696b3e5bR1): Commented out the login route and router export. [[1]](diffhunk://#diff-3185d28885bace3e5200daf57d75adf14169979d0f6b13da6719767e696b3e5bR1) [[2]](diffhunk://#diff-3185d28885bace3e5200daf57d75adf14169979d0f6b13da6719767e696b3e5bR10)
* [`server.js`](diffhunk://#diff-a4c65ede64197e1a112899a68bf994485b889c4b143198bac4af53425b38406fL9-R9): Commented out the import and usage of the login router. [[1]](diffhunk://#diff-a4c65ede64197e1a112899a68bf994485b889c4b143198bac4af53425b38406fL9-R9) [[2]](diffhunk://#diff-a4c65ede64197e1a112899a68bf994485b889c4b143198bac4af53425b38406fL21-R21)

Prisma schema modification:

* [`prisma/schema.prisma`](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cL36-R36): Set a default value of an empty array for the `searchTags` field in the `Node` model.